### PR TITLE
Add GPL headers

### DIFF
--- a/D01/codes/bm.py
+++ b/D01/codes/bm.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# This file is part of the erpi5 project and is licensed under the
+# GNU General Public License v3.  See the LICENSE file for details.
+#
 # gflops_pi5.py  –  calcula GFLOPS sencillos en una Raspberry Pi 5
 import time, numpy as np
 

--- a/MLGeneral/codes/code1.py
+++ b/MLGeneral/codes/code1.py
@@ -1,3 +1,7 @@
+#
+# This file is part of the erpi5 project and is licensed under the
+# GNU General Public License v3.  See the LICENSE file for details.
+#
 from tensorflow.keras import layers, Sequential
 
 model = Sequential([

--- a/codes/D01/ecg_sim.py
+++ b/codes/D01/ecg_sim.py
@@ -1,3 +1,7 @@
+#
+# This file is part of the erpi5 project and is licensed under the
+# GNU General Public License v3.  See the LICENSE file for details.
+#
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/codes/D01/pulso.py
+++ b/codes/D01/pulso.py
@@ -1,3 +1,7 @@
+#
+# This file is part of the erpi5 project and is licensed under the
+# GNU General Public License v3.  See the LICENSE file for details.
+#
 import numpy as np
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
## Summary
- add GPLv3 headers referencing LICENSE in Python scripts

## Testing
- `python3 -m py_compile D01/codes/bm.py codes/D01/ecg_sim.py codes/D01/pulso.py MLGeneral/codes/code1.py`


------
https://chatgpt.com/codex/tasks/task_e_68890cfc0344832fac5f669c9b52f063