### PR TITLE
Add workflow to build and publish docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Build Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'website/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies and build
+        run: |
+          cd website
+          npm ci
+          npm run build
+      - name: Sync docs folder
+        run: |
+          rm -rf docs/*
+          cp -r website/build/* docs/
+      - name: Commit built docs
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add docs
+          git commit -m "Update docs" || echo "No changes to commit"
+          git push
+      - name: Upload Pages artifact
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./docs
+      - name: Deploy to GitHub Pages
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- automate website build and publish step
- upload GitHub Pages artifact and deploy

## Testing
- `npm ci` in `website/`
- `npm run build` in `website/`
- `make -n`

------
https://chatgpt.com/codex/tasks/task_e_688975d1e950832f9f0a474682c72281