### PR TITLE
Fix Build Docs workflow artifact action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,9 +39,9 @@ jobs:
           git push
       - name: Upload Pages artifact
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: ./docs
       - name: Deploy to GitHub Pages
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
## Summary
- pin `upload-pages-artifact` to the latest release
- pin `deploy-pages` action version

## Testing
- `make -C D01` *(fails: lualatex not found)*

------
https://chatgpt.com/codex/tasks/task_e_68897b4650d8832f9248e663d671400f