### PR TITLE
Fix Build Docs workflow artifact action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,13 +7,18 @@ on:
     paths:
       - 'website/**'
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -37,11 +42,20 @@ jobs:
           git add docs
           git commit -m "Update docs" || echo "No changes to commit"
           git push
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - name: Upload Pages artifact
-        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
-        if: ${{ github.event_name != 'pull_request' }}
+        id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- refactor Build Docs workflow using the latest Pages deployment actions

## Testing
- `make -C D01` *(fails: lualatex not found)*

------
https://chatgpt.com/codex/tasks/task_e_68897b4650d8832f9248e663d671400f