### PR TITLE
Add Node.js version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This project is distributed under the terms of the GNU General Public License v3
 ## Website
 
 A minimal [Docusaurus](https://docusaurus.io) site is provided under `website/`.
-Run `npm install` inside that folder and `npm run build` to generate the static
+It requires **Node.js 20** or later. Run `npm install` inside that folder and `npm run build` to generate the static
 site. The resulting files appear in `website/build` and are published to
 GitHub Pages by the CI workflow. The website is
 available at [https://jperaltac.github.io/erpi5/](https://jperaltac.github.io/erpi5/).

--- a/website/package.json
+++ b/website/package.json
@@ -2,6 +2,9 @@
   "name": "erpi5-website",
   "version": "0.0.0",
   "private": true,
+  "engines": {
+    "node": "^20"
+  },
   "scripts": {
     "start": "docusaurus start",
     "build": "docusaurus build",


### PR DESCRIPTION
## Summary
- require Node 20 for the website build
- mention Node 20 in README

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889e7a4cc24832f8c1e2cf8c2c20d34