### PR TITLE
Fix docs workflow artifact names

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,9 @@ jobs:
         uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: ./website/build
+          name: github-pages-${{ github.run_number }}
       - name: Deploy to GitHub Pages
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/deploy-pages@v4.0.5
+        with:
+          artifact_name: github-pages-${{ github.run_number }}


### PR DESCRIPTION
## Summary
- ensure only one artifact is created during docs build
- deploy step now references that unique artifact name

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889eadb0cd8832fbcbac6c2b422616b