### PR TITLE
Fix Build Docs workflow permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary
- allow checkout to access repository contents

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a68ac30d0832fb4567db9ad5208fd