### PR TITLE
Fix encoded text in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClusterLab Raspberry Pi 5 Slides
 
-This repository contains the Beamer slides used for the "Cl\xC3\xBAsterLab" workshop focusing on Raspberry Pi 5. The material is organized per day (`D01` to `D06`) and written in Spanish. Each directory includes the corresponding `.tex` sources and precompiled PDFs.
+This repository contains the Beamer slides used for the "ClusterLab" workshop focusing on Raspberry Pi 5. The material is organized per day (`D01` to `D06`) and written in Spanish. Each directory includes the corresponding `.tex` sources and precompiled PDFs.
 
 ## Building
 

--- a/website/docs/compilar.md
+++ b/website/docs/compilar.md
@@ -5,11 +5,11 @@ slug: /compilar
 
 Los archivos PDF se generan a partir de las fuentes \`LaTeX\`. Para
 obtenerlos necesitas \`lualatex\` y las fuentes Inter, Fira Code y
-Libertinus. Tambi\u00E9n se usa el paquete \`minted\`, as\u00ED que Python y
+Libertinus. Tambien se usa el paquete \`minted\`, asi que Python y
 \`pygments\` deben estar instalados.
 
 ```bash
-make       # compila todos los d\u00EDas
+make       # compila todos los dias
 make clean # elimina temporales
 ```
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,17 +1,17 @@
 ---
 slug: /
-title: Escuela Cl\u00FAsterLab
+title: Escuela ClusterLab
 ---
 
-Bienvenido a la Escuela **Cl\u00FAsterLab**, un espacio de formaci\u00F3n en computaci\u00F3n de alto rendimiento. Durante seis d\u00EDas exploraremos la instalaci\u00F3n y administraci\u00F3n de un cl\u00FAster de Raspberry Pi 5.
+Bienvenido a la Escuela **ClusterLab**, un espacio de formacion en computacion de alto rendimiento. Durante seis dias exploraremos la instalacion y administracion de un cluster de Raspberry Pi 5.
 
-Cada directorio `DXX` de este repositorio contiene las fuentes de las diapositivas y el c\u00F3digo de apoyo usado en el taller.
+Cada directorio `DXX` de este repositorio contiene las fuentes de las diapositivas y el codigo de apoyo usado en el taller.
 
 ## Material del taller
 
-Los PDF se generan a partir de los archivos LaTeX. Consulta la secci\u00F3n [Compilar las presentaciones](./compilar) para aprender c\u00F3mo obtenerlos. A continuaci\u00F3n se listan los nombres de los documentos por d\u00EDa:
+Los PDF se generan a partir de los archivos LaTeX. Consulta la seccion [Compilar las presentaciones](./compilar) para aprender como obtenerlos. A continuacion se listan los nombres de los documentos por dia:
 
-| D\u00EDa | Presentaciones |
+| Dia | Presentaciones |
 | --- | --- |
 | D01 | D01P01.pdf, D01P02.pdf |
 | D02 | D02P01.pdf, D02P02.pdf |
@@ -21,4 +21,4 @@ Los PDF se generan a partir de los archivos LaTeX. Consulta la secci\u00F3n [Com
 | D06 | D06P01.pdf, D06P02.pdf |
 | General ML | MLGeneral-P01.pdf |
 
-Puedes encontrar el c\u00F3digo fuente completo en [GitHub](https://github.com/jperaltac/erpi5).
+Puedes encontrar el codigo fuente completo en [GitHub](https://github.com/jperaltac/erpi5).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'Escuela Cl\u00FAsterLab',
+  title: 'Escuela ClusterLab',
   tagline: 'Material del taller Raspberry Pi 5',
   url: 'https://jperaltac.github.io',
   baseUrl: '/erpi5/',


### PR DESCRIPTION
## Summary
- replace Unicode escape sequences with ASCII text in README and website files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a6d0c4f94832fbf33c3fe53106501