### PR TITLE
Add MLGeneral to top-level make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS := $(shell seq -f "D%02g" 1 6)
+SUBDIRS := $(shell seq -f "D%02g" 1 6) MLGeneral
 
 all:
 	@for dir in $(SUBDIRS); do \


### PR DESCRIPTION
## Summary
- include `MLGeneral` directory in the root `Makefile`
- verified the `make` process enters `MLGeneral`

## Testing
- `make -C MLGeneral` *(fails: lualatex not found)*
- `make` *(fails: lualatex not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a6e9b1fac832fb4672664ed4b0474