### PR TITLE
Expand LaTeX slides

### DIFF
--- a/D02/D02P01.tex
+++ b/D02/D02P01.tex
@@ -1,6 +1,7 @@
 % !TEX program = lualatex
 \documentclass[aspectratio=169,professionalfonts]{beamer}
 \input{../preamble.tex}
+\usepackage{mwe} % figuras de ejemplo -> example-image
 
 \title[ClústerLab • Día 2]{Redes IP y claves SSH}
 \subtitle{Configurar IP estática y generar claves}
@@ -12,6 +13,51 @@
 %------------------------------ portada ----------------------------
 \begin{frame}[plain]
   \titlepage
+\end{frame}
+
+%------------------------------ ssh test ---------------------------
+\begin{frame}[fragile]{Probar acceso SSH}
+  \begin{minted}{bash}
+$ ssh pi@10.0.0.21 hostname
+  \end{minted}
+  Si la autenticación funciona, verás el nombre de tu Pi en la salida.
+  \begin{minted}{bash}
+# Opcional en ~/.ssh/config
+Host rpi21
+  HostName 10.0.0.21
+  User pi
+  \end{minted}
+  Entonces basta con ejecutar:
+  \begin{minted}{bash}
+$ ssh rpi21
+  \end{minted}
+\end{frame}
+
+%------------------------------ nmap opciones ----------------------
+\begin{frame}[fragile]{Opciones útiles de \texttt{nmap}}
+  \begin{minted}{bash}
+$ nmap -A 10.0.0.0/24       # detección de servicios y SO
+$ nmap --open -p 80 10.0.0.* # buscar servidores web
+  \end{minted}
+  \begin{itemize}
+    \item \texttt{-A} entrega información detallada y requiere más tiempo.
+    \item Limita el rango si la red está muy concurrida.
+  \end{itemize}
+\end{frame}
+
+%------------------------------ prueba ip -------------------------
+\begin{frame}[fragile]{Verificar conectividad}
+  \begin{minted}{bash}
+$ ip addr show eth0 | grep 'inet '
+$ ping -c3 10.0.0.1
+  \end{minted}
+  \begin{itemize}
+    \item Confirma que la IP asignada se muestre en \texttt{inet}.
+    \item Un par de \texttt{ping} verifica la ruta al gateway.
+  \end{itemize}
+  \begin{center}
+    \includegraphics[width=.45\textwidth]{example-image-a}
+  \end{center}
 \end{frame}
 
 %------------------------------ objetivos --------------------------
@@ -95,6 +141,7 @@ $ ssh-copy-id pi@10.0.0.21
     \item Asigna una IP estática a tu Pi y reinicia la interfaz.
     \item Escanea la red para registrar IP y hostname de tus compañeros.
     \item Genera tu par de claves y copia la pública a la Pi.
+    \item Conéctate vía SSH y ejecuta \texttt{uptime} para validar acceso.
     \item Comparte la lista de IP/hostnames en el canal del curso.
   \end{enumerate}
 \end{frame}

--- a/D02/D02P02.tex
+++ b/D02/D02P02.tex
@@ -1,6 +1,7 @@
 % !TEX program = lualatex
 \documentclass[aspectratio=169,professionalfonts]{beamer}
 \input{../preamble.tex}
+\usepackage{mwe}
 
 \title[ClústerLab • Día 2]{Bash avanzado y transferencia}
 \subtitle{Condicionales, bucles y copias seguras}
@@ -12,6 +13,59 @@
 %------------------------------ portada ----------------------------
 \begin{frame}[plain]
   \titlepage
+\end{frame}
+
+%------------------------------ rsync extra -----------------------
+\begin{frame}[fragile]{Rsync incremental}
+  \begin{minted}{bash}
+$ rsync -av --delete origen/ pi@10.0.0.21:~/destino/
+  \end{minted}
+  \begin{itemize}
+    \item \texttt{--delete} borra en destino lo que ya no existe en origen.
+    \item Ideal para copias de seguridad periódicas.
+  \end{itemize}
+\end{frame}
+
+%------------------------------ ping parallel ----------------------
+\begin{frame}[fragile]{Ping en paralelo}
+  \begin{minted}{bash}
+for host in {1..254}; do
+  ping -c1 -W1 "10.0.0.$host" &
+done
+wait
+  \end{minted}
+  Ejecutar varios \texttt{ping} simultáneos reduce el tiempo total pero genera más tráfico.
+\end{frame}
+
+%------------------------------ arrays -----------------------------
+\begin{frame}[fragile]{Bucles con arreglos}
+  \begin{minted}{bash}
+FRUTAS=(manzana pera mango)
+for fruta in "${FRUTAS[@]}"; do
+  echo "Me gusta la $fruta"
+done
+  \end{minted}
+  \begin{itemize}
+    \item Las comillas dobles preservan espacios si los hay.
+    \item Añade más elementos y ejecuta de nuevo el ciclo.
+  \end{itemize}
+  \begin{center}
+    \includegraphics[width=.4\textwidth]{example-image-b}
+  \end{center}
+\end{frame}
+
+%------------------------------ condicionales demo -----------------
+\begin{frame}[fragile]{Prueba rápida de condicionales}
+  \begin{minted}{bash}
+$ bash test_file.sh notas.txt
+  \end{minted}
+  Crea el script anterior y ejecuta distintos argumentos:
+  \begin{itemize}
+    \item Un archivo que exista.
+    \item Un directorio.
+    \item Un nombre inexistente.
+  \end{itemize}
+  Observa los mensajes que imprime.
 \end{frame}
 
 %------------------------------ objetivos --------------------------
@@ -132,6 +186,7 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  archivo.txt
 \begin{frame}[fragile]{Actividad práctica}
   \begin{enumerate}
     \item Implementa y ejecuta \texttt{ping\_all.sh} en tu subred.
+    \item Prueba la variante en paralelo y compara el tiempo de ejecución.
     \item Copia un archivo de al menos 10 MB a tu Pi usando \texttt{scp} y mide el tiempo.
     \item Repite la copia con \texttt{rsync} y compara tiempos.
     \item Verifica los hashes SHA‑256 para confirmar integridad.

--- a/D03/D03P01.tex
+++ b/D03/D03P01.tex
@@ -1,6 +1,7 @@
 % !TEX program = lualatex
 \documentclass[aspectratio=169,professionalfonts]{beamer}
 \input{../preamble.tex}
+\usepackage{mwe}
 
 \title[ClústerLab • Día 3]{Gestión del sistema y diagnóstico}
 \subtitle{Hostnames, usuarios y sincronización de reloj}
@@ -12,6 +13,38 @@
 %------------------------------ portada ----------------------------
 \begin{frame}[plain]
   \titlepage
+\end{frame}
+
+%------------------------------ comprobar hora --------------------
+\begin{frame}[fragile]{Verificar fecha y hora}
+  \begin{minted}{bash}
+$ date
+  \end{minted}
+  Asegúrate de que la zona horaria mostrada sea la configurada. En caso contrario repite los pasos de \texttt{timedatectl}.
+\end{frame}
+
+%------------------------------ bashrc -----------------------------
+\begin{frame}[fragile]{Personalizar \texttt{.bashrc}}
+  \begin{minted}{bash}
+$ sudo -u cluster nano /home/cluster/.bashrc
+alias ll='ls -lh --color'
+  \end{minted}
+  Pide al usuario cerrar sesión y volver a entrar para aplicar los alias.
+  \begin{center}
+    \includegraphics[width=.4\textwidth]{example-image-c}
+  \end{center}
+\end{frame}
+
+%------------------------------ hostname test ----------------------
+\begin{frame}[fragile]{Comprobar el nuevo hostname}
+  \begin{minted}{bash}
+$ hostname
+$ ping -c1 node01
+  \end{minted}
+  \begin{itemize}
+    \item El comando \texttt{hostname} debe mostrar el nombre elegido.
+    \item Si \texttt{/etc/hosts} está correcto, el ping se resolverá localmente.
+  \end{itemize}
 \end{frame}
 
 %------------------------------ objetivos --------------------------
@@ -76,6 +109,9 @@ $ timedatectl status
   \begin{infobox}
   Un reloj sincronizado evita errores en Slurm y certificados SSL. Verifica que la salida muestre \texttt{System clock synchronized: yes}.
   \end{infobox}
+  \begin{center}
+    \includegraphics[width=.5\textwidth]{example-image}
+  \end{center}
 \end{frame}
 
 %------------------------------ revisión ---------------------------

--- a/D03/D03P02.tex
+++ b/D03/D03P02.tex
@@ -1,6 +1,7 @@
 % !TEX program = lualatex
 \documentclass[aspectratio=169,professionalfonts]{beamer}
 \input{../preamble.tex}
+\usepackage{mwe}
 
 \title[ClústerLab • Día 3]{Diagnóstico en tiempo real y reto grupal}
 \subtitle{Monitoreo, registros y uso de \texttt{sshfs}}
@@ -12,6 +13,34 @@
 %------------------------------ portada ----------------------------
 \begin{frame}[plain]
   \titlepage
+\end{frame}
+
+%------------------------------ sshfs persistente ------------------
+\begin{frame}[fragile]{Montaje permanente con \texttt{sshfs}}
+  \begin{minted}{bash}
+$ echo 'pi@head:/home/shared /home/cluster/shared fuse.sshfs defaults,_netdev 0 0' | sudo tee -a /etc/fstab
+  \end{minted}
+  Requiere claves SSH configuradas y el paquete \texttt{sshfs} instalado en el arranque.
+\end{frame}
+
+%------------------------------ log example -----------------------
+\begin{frame}[fragile]{Ejemplo de registro}
+  \begin{center}
+    \includegraphics[width=.7\textwidth]{example-image}
+  \end{center}
+  Salida típica al ejecutar \texttt{tail -f /var/log/health.log}.
+\end{frame}
+
+%------------------------------ logs -------------------------------
+\begin{frame}[fragile]{Revisión de logs con \texttt{journalctl}}
+  \begin{minted}{bash}
+$ sudo journalctl -u ssh
+$ sudo journalctl -f
+  \end{minted}
+  \begin{itemize}
+    \item Usa \texttt{-u} o \texttt{-b} para filtrar servicios o arranques.
+    \item Con \texttt{-f} observas mensajes en tiempo real.
+  \end{itemize}
 \end{frame}
 
 %------------------------------ objetivos --------------------------
@@ -97,6 +126,7 @@ $ sudo systemctl enable --now avahi-daemon
   \begin{enumerate}
     \item Ejecuta las herramientas de monitoreo y comparte capturas de tu Pi bajo carga.
     \item Lanza \texttt{healthcheck.sh} y revisa el log después de unos minutos.
+    \item Consulta los últimos eventos con \texttt{journalctl -u ssh}.
     \item Monta el directorio compartido con \texttt{sshfs} y crea un archivo de prueba.
     \item Conéctate a otro nodo usando su nombre (\texttt{ssh pi@node02.local}) y verifica la presencia del archivo.
   \end{enumerate}


### PR DESCRIPTION
## Summary
- enrich session slides for days 2 and 3 with more examples
- include demo commands and images via `example-image`
- show how to test network connectivity, SSH, and bash scripts
- add permanent `sshfs` mount example and journalctl usage

## Testing
- `git status --short`
- `which lualatex` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a763271e4832fa4dcf185eac4997d