### PR TITLE
Add agenda page to website

### DIFF
--- a/website/docs/agenda.md
+++ b/website/docs/agenda.md
@@ -1,0 +1,59 @@
+---
+id: agenda
+title: Agenda de la escuela
+sidebar_position: 4
+---
+
+# Agenda detallada
+
+Esta es la programación prevista para **ClústerLab 2025**. Cada semana tiene actividades los **lunes, miércoles y viernes** de 09:00 a 13:00. Las fechas exactas abarcan del **4 al 22 de agosto de 2025**.
+
+## Objetivos
+
+- Capacitar a los participantes en la creación y administración de un clúster con Raspberry Pi 5.
+- Fomentar el aprendizaje activo mediante ejercicios prácticos y un proyecto final.
+- Desarrollar competencias en Linux, redes, Bash, SLURM y programación paralela con MPI.
+
+## Cupos y organización
+
+- Cupos sugeridos: **15–20** estudiantes por versión.
+- Duración: **3 semanas** con sesiones tres días a la semana.
+- Horario: **09:00–13:00**.
+
+## Semana 1 – Fundamentos de Linux, Scripting y Redes
+
+| Horario | Lunes (JP) | Miércoles (CF) | Viernes (JP) |
+| --- | --- | --- | --- |
+| 09:00–09:15 | Bienvenida y motivación del curso. | Revisión breve | Revisión breve |
+| 09:15–10:30 | Configuración inicial de la Pi + Linux básico | Redes IP + claves SSH | Raspberry Pi OS: hostname y usuarios |
+| 10:45–12:00 | Bash I (comandos + variables) | Bash II (condicionales, bucles) + script `ping` | Diagnóstico: `htop`, `df`, `uptime` |
+| 12:00–13:00 | Práctica guiada en cada Pi | Conectar nodos y probar `scp/sshfs` | Reto: acceso por nombre de host + mini-demo |
+
+## Semana 2 – Montaje y uso del Clúster
+
+| Horario | Lunes (CF) | Miércoles (CR) | Viernes (CR) |
+| --- | --- | --- | --- |
+| 09:00–09:15 | Revisión de red y SSH | SLURM / Leftraru | Introducción + objetivos del día |
+| 09:15–10:30 | Topología, montaje físico + servidor NFS | Ejemplos básicos de SLURM + `sinfo` | MPI con `mpi4py`: Uso en Leftraru + ejemplos |
+| 10:45–12:00 | Montar directorio compartido y prueba de E/S | Primeros jobs y MPI básico: `srun`, `sbatch`, `squeue` | **Ejemplos y más actividades** |
+| 12:00–13:00 | Verificar acceso de todos los nodos. Cerrar el armado del clúster. | Script SLURM paramétrico (mini-array) | **Kick-off: definición de proyecto grupal y reparto de tareas** |
+
+## Semana 3 – Desarrollo y Presentaciones
+
+| Horario | Lunes | Miércoles (CR, CF, JP) | Viernes (CR, CF, JP) |
+| --- | --- | --- | --- |
+| 09:00–09:15 | *Sin clases* | Revisión de avances | Preparativos finales |
+| 09:15–10:30 | — | Desarrollo del código + análisis de resultados | **Presentaciones de 20 min por grupo** |
+| 10:45–12:00 | — | Visualización (`matplotlib/pandas`) + debugging distribuido | **Presentaciones de 20 min por grupo** |
+| 12:00–13:00 | — | Ajustes y preparación de reporte final | Certificados + Foto Grupal |
+
+## Semana 4 – Miércoles 27 ago (Post-work opcional)
+
+- Sesión libre de pulido de resultados.
+- Mejora de gráficos y notebook final.
+- Resumen ejecutivo (máximo 2 páginas) con deadline +48 h.
+- Reunión individual para próximos pasos (becas, papers).
+
+---
+
+La agenda está sujeta a cambios menores según el ritmo de la clase.


### PR DESCRIPTION
## Summary
- add `agenda.md` with the course timetable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a7a255708832fbfe3f6444312cee1