### PR TITLE
Add placeholder PDFs to resolve broken links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.fdb_latexmk
 *.fls
 *.pdf
+!website/static/pdfs/*.pdf
 
 # MacOS and editor files
 .DS_Store

--- a/website/static/pdfs/D01P01.pdf
+++ b/website/static/pdfs/D01P01.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D01P02.pdf
+++ b/website/static/pdfs/D01P02.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D02P01.pdf
+++ b/website/static/pdfs/D02P01.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D02P02.pdf
+++ b/website/static/pdfs/D02P02.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D03P01.pdf
+++ b/website/static/pdfs/D03P01.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D04P01.pdf
+++ b/website/static/pdfs/D04P01.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D04P02.pdf
+++ b/website/static/pdfs/D04P02.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D05P01.pdf
+++ b/website/static/pdfs/D05P01.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D05P02.pdf
+++ b/website/static/pdfs/D05P02.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D06P01.pdf
+++ b/website/static/pdfs/D06P01.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D06P02.pdf
+++ b/website/static/pdfs/D06P02.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D07P01.pdf
+++ b/website/static/pdfs/D07P01.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/D07P02.pdf
+++ b/website/static/pdfs/D07P02.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF

--- a/website/static/pdfs/MLGeneral-P01.pdf
+++ b/website/static/pdfs/MLGeneral-P01.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 10 100 Td (Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000279 00000 n 
+0000000384 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+474
+%%EOF


### PR DESCRIPTION
## Summary
- add placeholder PDFs in `website/static/pdfs` so documentation links resolve
- allow PDF assets to be tracked by Git

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b970406ac832fb5df71fd97781124